### PR TITLE
Depend directly on age repo until 0.6 is released

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,10 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-age = { version = "0.5.1", features = ["armor", "async"] }
 chrono = { version = "0.4", features = ["wasmbind"] }
 futures = "0.3"
 getrandom = { version = "0.1", features = ["wasm-bindgen"] }
-i18n-embed = { version = "0.10.2", features = ["fluent-system", "web-sys-requester"] }
+i18n-embed = { version = "0.12", features = ["fluent-system", "web-sys-requester"] }
 js-sys = "0.3"
 pin-project = "1"
 secrecy = "0.7"
@@ -38,6 +37,11 @@ wee_alloc = { version = "0.4.2", optional = true }
 
 # Temporary workaround for https://github.com/Amanieu/parking_lot/issues/269
 parking_lot_core = "=0.8.0"
+
+[dependencies.age]
+git = "https://github.com/str4d/rage.git"
+rev = "a9b5e88aa5816b284ebea23fc84d0203a3c4fdbb"
+features = ["armor", "async", "web-sys"]
 
 [dependencies.web-sys]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ impl Decryptor {
         };
 
         let reader = decryptor
-            .decrypt_async(identities.0.into_iter())
+            .decrypt_async(identities.0.iter().map(|i| &**i))
             .map_err(|e| JsValue::from(format!("{}", e)))?;
 
         Ok(ReadableStream::from_stream(shim::ReadStreamer::new(reader, CHUNK_SIZE)).into_raw())


### PR DESCRIPTION
This gets us the breaking format change, a security fix, and a performance improvement for passphrase encryption.